### PR TITLE
Typo fix

### DIFF
--- a/packages/pockethost.io/src/routes/+page.svelte
+++ b/packages/pockethost.io/src/routes/+page.svelte
@@ -91,7 +91,7 @@
           <p>
             Email and oAuth authentication options work out of the box. Send transactional email to
             your users from our verified domain and your custom address <code
-              >yoursubdomin@{PUBLIC_APP_DOMAIN}</code
+              >yoursubdomain@{PUBLIC_APP_DOMAIN}</code
             >.
           </p>
         </FeatureCard>


### PR DESCRIPTION
I just fixed a small typo on pockethost.io in yoursubdomin@pockethost.io that made it yoursubdomain@pockethost.io. For some reason this typo was the first thing I saw and it drove me crazy. Thanks.