### PR TITLE
Accept all headers in options requests

### DIFF
--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -22,6 +22,7 @@ const server = createServer(options, async (req, res) => {
   }
 
   if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Headers', '*')
     res.writeHead(204, headers)
     res.end()
     return


### PR DESCRIPTION
As discussed on https://github.com/benallfree/pockethost/discussions/273.

This PR enables the passing of custom headers to PocketBase (That in itself is supported, however it was failing due to a CORS error with PocketHost not supporting custom headers)